### PR TITLE
Fixed bugs for [KT20] & [KT53]

### DIFF
--- a/app/models/temporary_marking.rb
+++ b/app/models/temporary_marking.rb
@@ -36,8 +36,8 @@ class TemporaryMarking < ActiveRecord::Base
 
   validate :score_does_not_exceed_long_problem_max_score
   def score_does_not_exceed_long_problem_max_score
-    return unless !score.nil? && score > long_submission.long_problem.max_score
-    errors.add :score,
+    return unless !mark.nil? && mark > long_submission.long_problem.max_score
+    errors.add :mark,
                'must be < long_problem.max_score ' \
                "(#{long_submission.long_problem.max_score})"
   end

--- a/app/views/contests/_own_results.html.haml
+++ b/app/views/contests/_own_results.html.haml
@@ -4,7 +4,7 @@
 
 #own-results
   - unless short_problems.empty?
-    %h3 Bagian A: #{user_contest.short_mark}/#{short_problems.length} poin
+    %h3 Bagian A: #{user_contest.short_mark}/#{short_problems.sum(:correct_score)} poin
     - short_problems.each do |prob|
       - ss = short_submissions.find { |s| s.short_problem_id == prob.id }
 


### PR DESCRIPTION
1. There is nil because in TemporaryMarking Model, score should be mark since there's no score column in temporary marking table, i guess. 

2. I found that short_problems.length in own_result view doesn't relevant, then i changed it to sum(:correct_score).    