### PR TITLE
Change CI's server from ubuntu-16.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy:
     name: Capistrano Deploy to Server
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Install SSH key to Server

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -44,7 +44,7 @@ jobs:
           bundle exec rake test
   rubocop:
     name: rubocop
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     services:
       db:
         image: postgres:11


### PR DESCRIPTION
Ubuntu-16.04 as a server that we used is start to deprecating. As a solution, we need to change it to ubuntu-latest to keep our CI running