### PR TITLE
Fix broken github action test

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,6 +32,10 @@ jobs:
           ruby-version: 2.5.0
       - run: | 
           bundle install --without production development
+      - name: Install ImageMagick
+        run: |
+          sudo apt update
+          sudo apt -y install imagemagick
       - env:
           RAILS_ENV: test
           PGHOST: localhost

--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem 'non-stupid-digest-assets'
 gem 'will_paginate'
 # Generate PDF
 gem 'wicked_pdf'
-gem 'wkhtmltopdf-binary'
+gem 'wkhtmltopdf-binary', '~> 0.12.6.8'
 # Facebook Graph API
 gem 'koala'
 # Environment variables

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,7 +365,7 @@ GEM
     wicked_pdf (2.1.0)
       activesupport
     will_paginate (3.3.0)
-    wkhtmltopdf-binary (0.12.6.5)
+    wkhtmltopdf-binary (0.12.6.8)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -433,7 +433,7 @@ DEPENDENCIES
   web-console
   wicked_pdf
   will_paginate
-  wkhtmltopdf-binary
+  wkhtmltopdf-binary (~> 0.12.6.8)
 
 RUBY VERSION
    ruby 2.5.0p0


### PR DESCRIPTION
Fix #177 

- `wkhtmltopdf-binary` is updated to support ubuntu 24.04.
- install image magick in github action.
