### PR TITLE
Fix update contest rule not saved

### DIFF
--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -146,7 +146,7 @@ class ContestsController < ApplicationController
                      %i[name start_time end_time result_time
                         feedback_time problem_pdf gold_cutoff
                         silver_cutoff bronze_cutoff result_released
-                        marking_scheme book_promo timer]
+                        marking_scheme book_promo timer rule]
                    elsif can? :update_marking_scheme, @contest
                      :marking_scheme
                    else

--- a/test/controllers/contests_controller_test.rb
+++ b/test/controllers/contests_controller_test.rb
@@ -89,12 +89,13 @@ class ContestsControllerTest < ActionController::TestCase
   test 'update' do
     test_abilities @c, :update, [nil, :panitia, :marker, :problem_admin],
                    [:admin]
-    post :update, id: @c.id, contest: { name: 'Coba asal aja' }
+    post :update, id: @c.id, contest: { name: 'Coba asal aja', rule: 'New rule' }
 
     @c.reload
     assert_redirected_to contest_path(@c)
     assert_equal flash[:notice], "#{@c} berhasil diubah."
     assert_equal @c.name, 'Coba asal aja'
+    assert_equal @c.rule, 'New rule'
   end
 
   test 'update fail' do


### PR DESCRIPTION
Fix #180 

Turns out the rule itself is not permitted in the parameters.